### PR TITLE
Additional usage analysis

### DIFF
--- a/rctab/crud/schema.py
+++ b/rctab/crud/schema.py
@@ -266,6 +266,12 @@ class CostRecovery(BaseModel):
     date_recovered: Optional[datetime.date] = None
 
 
+class FinanceWithCostRecovery(FinanceListItem):
+    """Finance including a total costs recovered field."""
+
+    total_recovered: float
+
+
 class Currency(str, Enum):
     """Recognised currencies."""
 

--- a/rctab/routers/frontend.py
+++ b/rctab/routers/frontend.py
@@ -20,7 +20,7 @@ from rctab.crud.schema import (
     AllocationListItem,
     ApprovalListItem,
     CostRecovery,
-    FinanceListItem,
+    FinanceWithCostRecovery,
     RoleAssignment,
     SubscriptionDetails,
     Usage,
@@ -29,7 +29,7 @@ from rctab.routers.accounting.routes import (
     get_allocations,
     get_approvals,
     get_costrecovery,
-    get_finance,
+    get_finance_costs_recovered,
     get_subscription_details,
     get_subscriptions_with_disable,
     get_usage,
@@ -238,17 +238,16 @@ async def subscription_details(
     ]
     # pylint: disable=line-too-long
 
-    all_finance = [
-        FinanceListItem(**i)
-        for i in await get_finance(
-            subscription_id, raise_404=False
-        )  # pylint: disable=unexpected-keyword-arg
-    ]
-    # pylint: disable=line-too-long
-
     all_costrecovery = [
         CostRecovery(**i)
         for i in await get_costrecovery(
+            subscription_id, raise_404=False
+        )  # pylint: disable=unexpected-keyword-arg
+    ]
+
+    all_finance_with_costs_recovered = [
+        FinanceWithCostRecovery(**i)
+        for i in await get_finance_costs_recovered(
             subscription_id, raise_404=False
         )  # pylint: disable=unexpected-keyword-arg
     ]
@@ -311,10 +310,13 @@ async def subscription_details(
             "subscription_details": subscription_details_info,
             "all_approvals": all_approvals,
             "all_allocations": all_allocations,
-            "all_finance": all_finance,
+            "all_finance": all_finance_with_costs_recovered,
             "all_costrecovery": all_costrecovery,
             "all_rbac_assignments": sorted_all_rbac_assignments,
             "views": views,
+            "total_recovered_costs": sum(
+                item.total_recovered for item in all_finance_with_costs_recovered
+            ),
         },
     )
 

--- a/rctab/templates/signed_in_azure_info_details.html
+++ b/rctab/templates/signed_in_azure_info_details.html
@@ -139,6 +139,9 @@
 
 <div id="SubscriptionFCA" class="tabcontent" style="display: none">
     <h3>Details of subscription finances and cost recovery</h3>
+    <p1>Total costs recovered by project funding: <b>£{{ total_recovered_costs | round(2) }}</b></p1>
+    <br>
+    <p1 class="tooltip">Total costs <i>currently</i> charged to to core funding: <b>£{{ (subscription_details.total_cost - total_recovered_costs) | round(2) }}</b><span class="tooltiptext">Cost recovery may reduce this value</span></p1>
     <div class="flex-grid">
         <div class="col">
 
@@ -152,6 +155,7 @@
                     <th>Priority</th>
                     <th>Amount</th>
                     <th>Created on</th>
+                    <th>Costs Recovered</th>
                 </tr>
                 {% for item in all_finance %}
                 <tr>
@@ -162,6 +166,7 @@
                     <td>{{ item.priority }}</td>
                     <td>£{{ item.amount | round(2) }}</td>
                     <td>{{ item.time_created.strftime('%Y-%m-%d') }}</td>
+                    <td>£{{ item.total_recovered | round(2) }} ({{ (item.total_recovered / item.amount * 100) | round | int }}%)</td>
                 </tr>
                 {% endfor %}
             </table>


### PR DESCRIPTION
This PR adds more stats about each subscription's usage to the front end, including:

- [ ] The costs recovered per finance entry (along with percentage)
- [ ] Project and core spending totals, allowing us to see what spending links with what funding (project or core)
- [ ] Spending and allocation graphs with forecast (for current financial year).
- [ ] Expected spending (current financial year) based on forecast, including amount of new funds needed or left over.

Once working across all subscriptions, have a report page for Admin that shows the aggregated stats and forecasts to be used in an azure usage report.