### PR TITLE
Don't rely on UUID(int=0) subscription existing in db

### DIFF
--- a/rctab/daily_routine_tasks.py
+++ b/rctab/daily_routine_tasks.py
@@ -136,7 +136,6 @@ async def send_summary_email(
                 insert(failed_emails)
                 .values(
                     {
-                        "subscription_id": UUID(int=0),
                         "type": subject,
                         "subject": error.subject,
                         "recipients": ";".join(error.recipients),


### PR DESCRIPTION
We shouldn't depend on their being a 0000-00000-0000-0000 subscription in the live database when we insert failed emails. The failed_emails.subscription_id is NULLable so there's no good reason not to leave it NULL, IMO.