### PR TITLE
Script integrity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RCTab"
-version = "1.2.0"
+version = "1.2.1"
 description = "The RCTab API. Manage Azure budgets and usage"
 authors = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ description = "The RCTab API. Manage Azure budgets and usage"
 authors = []
 
 [tool.poetry.dependencies]
-# We only upper-bound the python version because SciPy 1.8 does, and we need
-# that to install on ARM Macs.
 python = ">=3.10 <3.12"
 alembic = "^1.7.1"
 asyncpg = "^0.27.0"

--- a/rctab/templates/base_site.html
+++ b/rctab/templates/base_site.html
@@ -7,12 +7,12 @@
     <link rel="stylesheet" href="{{ url_for('static', path ='css/styles.css') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap">
 
     <!-- DataTables -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.css">
-    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.css" crossorigin="anonymous" integrity="sha384-BkBbPhUt3jRGBTiLWXYui3cQxeueNgOgJkl5jaxCAdpAqMuzQJSNDd+5O/0crLX8">
+    <script type="text/javascript" charset="utf8" src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" crossorigin="anonymous" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.js" crossorigin="anonymous" integrity="sha384-ffdocMECdI5Mr/PiXXjgHO0Yj4n6iCzP4ivRh4iF3pxOS4iLTGyYImqTNMjcvgCQ"></script>
     <script type="text/javascript" charset="utf8" src="{{ url_for('static', path ='scripts/tables.js') }}"></script>
 
     <title>RCTab - {% block title %}{% endblock %}</title>

--- a/tests/test_routes/test_frontend.py
+++ b/tests/test_routes/test_frontend.py
@@ -120,7 +120,6 @@ async def test_check_user_on_subscription(
     assert user_on_subscription is False
 
 
-
 @pytest.mark.asyncio
 async def test_render_home_page(mocker: MockerFixture, test_db: Database) -> None:
     """Check that we can pick up on undefined variable template issues."""

--- a/tests/test_routes/test_frontend.py
+++ b/tests/test_routes/test_frontend.py
@@ -1,4 +1,5 @@
 import random
+from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import UUID
 
@@ -6,8 +7,11 @@ import jwt
 import pytest
 from databases import Database
 from fastapi import HTTPException
+from fastapi.templating import Jinja2Templates
+from jinja2 import StrictUndefined
 from pytest_mock import MockerFixture
 
+import rctab
 from rctab.crud.accounting_models import subscription, subscription_details
 from rctab.crud.schema import RoleAssignment, SubscriptionState, UserRBAC
 from rctab.routers.frontend import check_user_on_subscription, home
@@ -114,3 +118,67 @@ async def test_check_user_on_subscription(
     )
 
     assert user_on_subscription is False
+
+
+
+@pytest.mark.asyncio
+async def test_render_home_page(mocker: MockerFixture, test_db: Database) -> None:
+    """Check that we can pick up on undefined variable template issues."""
+
+    # Use StrictUndefined while testing
+    mocker.patch(
+        "rctab.routers.frontend.templates",
+        Jinja2Templates(
+            (
+                Path(rctab.routers.frontend.__file__).parent.parent / "templates"
+            ).absolute(),
+            undefined=StrictUndefined,
+        ),
+    )
+    subscription_id = UUID(int=random.randint(0, (2**32) - 1))
+
+    await test_db.execute(
+        subscription.insert().values(),
+        dict(
+            admin=str(constants.ADMIN_UUID),
+            subscription_id=str(subscription_id),
+        ),
+    )
+
+    await test_db.execute(
+        subscription_details.insert().values(),
+        dict(
+            subscription_id=str(subscription_id),
+            state=SubscriptionState("Enabled"),
+            display_name="a subscription",
+            role_assignments=[
+                RoleAssignment(
+                    role_definition_id="123",
+                    role_name="Sous chef",
+                    principal_id="456",
+                    display_name="Max Mustermann",
+                    # Note the missing email address, which does sometimes happen
+                    mail=None,
+                    scope="some/scope/string",
+                ).dict()
+            ],
+        ),
+    )
+
+    mock_request = mocker.Mock()
+
+    mock_user = mocker.Mock()
+    mock_user.token = {
+        "access_token": jwt.encode(
+            {"unique_name": "me@my.org", "name": "My Name"}, "my key"
+        )
+    }
+    mock_user.oid = str(UUID(int=434))
+
+    mock_check_access = AsyncMock()
+    mock_check_access.return_value = UserRBAC(
+        oid=UUID(int=111), has_access=True, is_admin=False
+    )
+    mocker.patch("rctab.routers.frontend.check_user_access", mock_check_access)
+
+    await home(mock_request, mock_user)


### PR DESCRIPTION
- Add integrity checks to third-party CSS and JS files.
- Add test to find missing variables in home page template(s) (e.g. `{{ x }}` where we are not passing `x=` to `TemplateResponse()`.
- Bump version number for new release.