### PR TITLE
Inline Styles / Scripts

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -16,3 +16,5 @@ rules:
   no-undefined: "error"
   no-use-before-define: "error"
   no-var: "error"
+parserOptions:
+  ecmaVersion: 9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RCTab"
-version = "1.2.1"
+version = "1.2.2"
 description = "The RCTab API. Manage Azure budgets and usage"
 authors = []
 

--- a/rctab/main.py
+++ b/rctab/main.py
@@ -51,8 +51,12 @@ csp = (
     .connect_src("'self'")
     .frame_src("'none'")
     .img_src("'self'")
-    .style_src("'self'", "fonts.googleapis.com", "cdn.datatables.net")
-    .script_src("'self'", "ajax.googleapis.com", "cdn.datatables.net")
+    .style_src(
+        "'self'", "'unsafe-inline'", "fonts.googleapis.com", "cdn.datatables.net"
+    )
+    .script_src(
+        "'self'", "'unsafe-inline'", "ajax.googleapis.com", "cdn.datatables.net"
+    )
     .font_src("'self'", "fonts.gstatic.com")
 )
 

--- a/rctab/main.py
+++ b/rctab/main.py
@@ -50,21 +50,21 @@ csp = (
     .base_uri("'self'")
     .connect_src("'self'")
     .frame_src("'none'")
-    .img_src("'self'")
+    .img_src("'self'", "cdn.datatables.net")
     .style_src(
-        "'self'", "'unsafe-inline'", "fonts.googleapis.com", "cdn.datatables.net"
+        "'self'",
+        "fonts.googleapis.com",
+        "cdn.datatables.net",
+        "'sha256-IkjQ9EOnF8lU4Wz6Y99mLT43EodSNMW49MHfgL33IXM='",
+        "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
     )
-    .script_src(
-        "'self'", "'unsafe-inline'", "ajax.googleapis.com", "cdn.datatables.net"
-    )
+    .script_src("'self'", "ajax.googleapis.com", "cdn.datatables.net", "cdn.plot.ly")
     .font_src("'self'", "fonts.gstatic.com")
 )
 
 hsts = secure.StrictTransportSecurity().include_subdomains().preload().max_age(2592000)
 
 referrer = secure.ReferrerPolicy().no_referrer()
-
-permissions_value = secure.PermissionsPolicy()
 
 cache_value = secure.CacheControl().must_revalidate()
 
@@ -73,7 +73,6 @@ SECURE_HEADERS: Final = secure.Secure(
     csp=csp,
     hsts=hsts,
     referrer=referrer,
-    permissions=permissions_value,
     cache=cache_value,
 )
 

--- a/rctab/main.py
+++ b/rctab/main.py
@@ -44,23 +44,7 @@ app = FastAPI(
 
 server = secure.Server().set("Secure")
 
-csp = (
-    secure.ContentSecurityPolicy()
-    .default_src("'none'")
-    .base_uri("'self'")
-    .connect_src("'self'")
-    .frame_src("'none'")
-    .img_src("'self'", "cdn.datatables.net")
-    .style_src(
-        "'self'",
-        "fonts.googleapis.com",
-        "cdn.datatables.net",
-        "'sha256-IkjQ9EOnF8lU4Wz6Y99mLT43EodSNMW49MHfgL33IXM='",
-        "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
-    )
-    .script_src("'self'", "ajax.googleapis.com", "cdn.datatables.net", "cdn.plot.ly")
-    .font_src("'self'", "fonts.gstatic.com")
-)
+xfo = secure.XFrameOptions().deny()
 
 hsts = secure.StrictTransportSecurity().include_subdomains().preload().max_age(2592000)
 
@@ -70,8 +54,8 @@ cache_value = secure.CacheControl().must_revalidate()
 
 SECURE_HEADERS: Final = secure.Secure(
     server=server,
-    csp=csp,
     hsts=hsts,
+    xfo=xfo,
     referrer=referrer,
     cache=cache_value,
 )

--- a/rctab/routers/frontend.py
+++ b/rctab/routers/frontend.py
@@ -286,7 +286,7 @@ async def subscription_details(
     # ...then sort the assignments by role
     sorted_all_rbac_assignments = []
     for role in role_order:
-        sorted_all_rbac_assignments.extend(assignments_dict[role])
+        sorted_all_rbac_assignments.extend(assignments_dict.get(role, []))
 
     # pylint: disable=line-too-long
     views = {

--- a/rctab/static/css/styles.css
+++ b/rctab/static/css/styles.css
@@ -115,6 +115,9 @@ body {
   color: red;
   display: none;
 }
+.displayNone {
+  display: none;
+}
 table {
   border-collapse: collapse;
   width: 100%;

--- a/rctab/static/scripts/tab_functions.js
+++ b/rctab/static/scripts/tab_functions.js
@@ -26,22 +26,30 @@ function openTab(evt, tabName) {
 
 $(document).ready( function () {
     // Get all tabs and hide them
-//    let tabcontent = document.getElementsByClassName("tabcontent");
-//    for (let i = 0; i < tabcontent.length; i++) {
-//        tabcontent[i].style.display = "none";
-//    }
+    let tabcontent = document.getElementsByClassName("tabcontent");
+    for (let i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
 
     const aaBtn = document.getElementById("SubscriptionAA_btn");
-    aaBtn.onclick = function(event) {openTab(event, 'SubscriptionAA')};
+    if (aaBtn) {
+        aaBtn.onclick = function(event) {openTab(event, 'SubscriptionAA')};
+    }
 
     const fcaBtn = document.getElementById("SubscriptionFCA_btn");
-    fcaBtn.onclick = function(event) {openTab(event, 'SubscriptionFCA')};
+    if (fcaBtn) {
+        fcaBtn.onclick = function(event) {openTab(event, 'SubscriptionFCA')};
+    }
 
     const uaBtn = document.getElementById("SubscriptionUA_btn");
-    uaBtn.onclick = function(event) {openTab(event, 'SubscriptionUA')};
+    if (uaBtn) {
+        uaBtn.onclick = function(event) {openTab(event, 'SubscriptionUA')};
+    }
 
     const uBtn = document.getElementById("SubscriptionU_btn");
-    uBtn.onclick = function(event) {openTab(event, 'SubscriptionU')};
+    if (uBtn) {
+        uBtn.onclick = function(event) {openTab(event, 'SubscriptionU')};
+    }
 
     // Set the previously selected tab as active on page refresh
     if(window.location.pathname.includes('/details/')) {

--- a/rctab/static/scripts/tab_functions.js
+++ b/rctab/static/scripts/tab_functions.js
@@ -25,7 +25,25 @@ function openTab(evt, tabName) {
 
 
 $(document).ready( function () {
-    // Set the previously selected tab as active on page refresh if exists
+    // Get all tabs and hide them
+//    let tabcontent = document.getElementsByClassName("tabcontent");
+//    for (let i = 0; i < tabcontent.length; i++) {
+//        tabcontent[i].style.display = "none";
+//    }
+
+    const aaBtn = document.getElementById("SubscriptionAA_btn");
+    aaBtn.onclick = function(event) {openTab(event, 'SubscriptionAA')};
+
+    const fcaBtn = document.getElementById("SubscriptionFCA_btn");
+    fcaBtn.onclick = function(event) {openTab(event, 'SubscriptionFCA')};
+
+    const uaBtn = document.getElementById("SubscriptionUA_btn");
+    uaBtn.onclick = function(event) {openTab(event, 'SubscriptionUA')};
+
+    const uBtn = document.getElementById("SubscriptionU_btn");
+    uBtn.onclick = function(event) {openTab(event, 'SubscriptionU')};
+
+    // Set the previously selected tab as active on page refresh
     if(window.location.pathname.includes('/details/')) {
         const currentTab = sessionStorage.getItem('currentTab');
         if (currentTab) {

--- a/rctab/static/scripts/usage_data.js
+++ b/rctab/static/scripts/usage_data.js
@@ -1,0 +1,27 @@
+"use strict";
+
+async function fetchUsageData(event) {
+    const usageSubmitBtn = document.getElementById("usagesubmitbtn")
+    usageSubmitBtn.disabled=true;
+
+    const outDiv = document.getElementById("azureusageinfo")
+    const datestring = document.getElementById("timeperiodstr").value
+    const subscription_id = document.getElementById("subscription_id").innerText
+    outDiv.innerHTML = '<div class="search-overlay"><div class="loader"></div><div class="loader-text"><br><br>Loading data<br><br>This may take a few seconds or a few minutes depending on the length of time requested.</div></div>'
+    event.preventDefault();
+    await fetch("/process_usage/" + subscription_id + "?timeperiodstr=" + datestring, {
+        method: "GET",
+    })
+    .then(response => {
+        return response.text();
+    })
+    .then(html => {
+        $("#azureusageinfo").html(html)
+    })
+    usageSubmitBtn.disabled=false;
+}
+
+$(document).ready(function () {
+    const usageSubmitBtn = document.getElementById("usagesubmitbtn");
+    usageSubmitBtn.onclick = fetchUsageData;
+} );

--- a/rctab/static/scripts/usage_data.js
+++ b/rctab/static/scripts/usage_data.js
@@ -9,6 +9,7 @@ async function fetchUsageData(event) {
     const subscription_id = document.getElementById("subscription_id").innerText
     outDiv.innerHTML = '<div class="search-overlay"><div class="loader"></div><div class="loader-text"><br><br>Loading data<br><br>This may take a few seconds or a few minutes depending on the length of time requested.</div></div>'
     event.preventDefault();
+
     await fetch("/process_usage/" + subscription_id + "?timeperiodstr=" + datestring, {
         method: "GET",
     })
@@ -18,6 +19,7 @@ async function fetchUsageData(event) {
     .then(html => {
         $("#azureusageinfo").html(html)
     })
+
     usageSubmitBtn.disabled=false;
 }
 

--- a/rctab/templates/azure_usage_info.html
+++ b/rctab/templates/azure_usage_info.html
@@ -8,7 +8,7 @@
     <div class="col usageFigure">
         {{ usage_fig | safe }}
     </div>
-    <div class="col usageTable" id="fullusagetable" style="display: none;">
+    <div class="col usageTable displayNone" id="fullusagetable">
         <table id="subscription_usage">
             <tr>
                 <th>Account name</th>

--- a/rctab/templates/base_site.html
+++ b/rctab/templates/base_site.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.css" crossorigin="anonymous" integrity="sha384-BkBbPhUt3jRGBTiLWXYui3cQxeueNgOgJkl5jaxCAdpAqMuzQJSNDd+5O/0crLX8">
     <script type="text/javascript" charset="utf8" src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" crossorigin="anonymous" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2"></script>
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.js" crossorigin="anonymous" integrity="sha384-ffdocMECdI5Mr/PiXXjgHO0Yj4n6iCzP4ivRh4iF3pxOS4iLTGyYImqTNMjcvgCQ"></script>
-    <script type="text/javascript" charset="utf8" src="{{ url_for('static', path ='scripts/tables.js') }}"></script>
+    <script type="text/javascript" charset="utf8" src="{{ url_for('static', path='scripts/tables.js') }}"></script>
 
     <title>RCTab - {% block title %}{% endblock %}</title>
     {% endblock %}

--- a/rctab/templates/signed_in_azure_info_details.html
+++ b/rctab/templates/signed_in_azure_info_details.html
@@ -65,14 +65,14 @@
 </div>
 
 <div class="tab">
-    <button id="SubscriptionAA_btn" class="tablinks" onclick="openTab(event, 'SubscriptionAA')" name="defaultOpen">Approvals and Allocations</button>
-    <button id="SubscriptionFCA_btn" class="tablinks" onclick="openTab(event, 'SubscriptionFCA')">Finance and Cost Recovery</button>
-    <button id="SubscriptionUA_btn" class="tablinks" onclick="openTab(event, 'SubscriptionUA')">Users with access</button>
-    <button id="SubscriptionU_btn" class="tablinks" onclick="openTab(event, 'SubscriptionU')">Usage</button>
+    <button id="SubscriptionAA_btn" class="tablinks" name="defaultOpen">Approvals and Allocations</button>
+    <button id="SubscriptionFCA_btn" class="tablinks">Finance and Cost Recovery</button>
+    <button id="SubscriptionUA_btn" class="tablinks">Users with access</button>
+    <button id="SubscriptionU_btn" class="tablinks">Usage</button>
 </div>
 
 
-<div id="SubscriptionAA" class="tabcontent" style="display: none">
+<div id="SubscriptionAA" class="tabcontent">
     <h3>Details of subscription approvals and allocations</h3>
     <div class="flex-grid">
         <div class="col">
@@ -116,7 +116,7 @@
     </div>
 </div>
 
-<div id="SubscriptionFCA" class="tabcontent" style="display: none">
+<div id="SubscriptionFCA" class="tabcontent">
     <h3>Details of subscription finances and cost recovery</h3>
     <div class="flex-grid">
         <div class="col">
@@ -171,7 +171,7 @@
     </div>
 </div>
 
-<div id="SubscriptionUA" class="tabcontent" style="display: none">
+<div id="SubscriptionUA" class="tabcontent">
     <h3>Subscription users with access</h3>
     <div class="flex-grid">
         <div class="col usersTable">
@@ -198,13 +198,13 @@
     </div>
 </div>
 
-<div id="SubscriptionU" class="tabcontent" style="display: none">
+<div id="SubscriptionU" class="tabcontent">
     <h3>Usage breakdown</h3>
     <div>
         <form method="get" class="tooltip" id="usageinfoform">
         <label for="timeperiodstr">Start date</label>
         <input type="date" id="timeperiodstr" min="2015-03-01">
-        <input type="button" id="usagesubmitbtn" value="fetch data" onclick="fetchUsageData(event);">
+        <input type="button" id="usagesubmitbtn" value="fetch data">
         <span class="tooltiptext">Load usage data since start date. This may take some time depending on the length of time requested.</span>
         </form>
     </div>

--- a/rctab/templates/signed_in_azure_info_details.html
+++ b/rctab/templates/signed_in_azure_info_details.html
@@ -2,7 +2,7 @@
 {% block head %}
 {{ super() }}
 <script charset="utf-8" src="https://cdn.plot.ly/plotly-2.20.0.min.js"></script>
-<script type="text/javascript" charset="utf8" src="{{ url_for('static', path ='scripts/usage_data.js') }}"></script>
+<script type="text/javascript" charset="utf8" src="{{ url_for('static', path='scripts/usage_data.js') }}"></script>
 {% endblock %}
 
 {% block noaccess %}


### PR DESCRIPTION
- There are inline CSS and JS elements on the details page that we didn't pick up when first adding the CSP.
- I had neglected to add a JS file to version control when refactoring.
- Use of `async` JS funcs requires change to eslint settings.
- Missing RBAC assignments would cause internal server error on details page.
- Add details page rendering unit test.
- Empty permissions policy caused `Error with Permissions-Policy header: Parse of permissions policy failed because of errors reported by structured header parser.` in Chrome