### PR TITLE
Allow customisation of expiry email notification schedule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RCTab"
-version = "1.3.0"
+version = "1.3.1"
 description = "The RCTab API. Manage Azure budgets and usage"
 authors = []
 

--- a/rctab/routers/accounting/allocations.py
+++ b/rctab/routers/accounting/allocations.py
@@ -26,7 +26,9 @@ async def check_allocation(allocation: Allocation) -> None:
     subscription_summary = await get_subscriptions_summary(sub_id=allocation.sub_id)
 
     # Get the first row (should only be one)
-    subscription_summary = SubscriptionSummary(**subscription_summary[0])
+    # pylint: disable=protected-access
+    subscription_summary = SubscriptionSummary(**subscription_summary[0]._mapping)
+    # pylint: enable=protected-access
 
     if not subscription_summary.approved_to:
         raise HTTPException(

--- a/rctab/routers/accounting/approvals.py
+++ b/rctab/routers/accounting/approvals.py
@@ -110,7 +110,9 @@ async def check_approval(approval: Approval) -> None:
     subscription_summary = await get_subscriptions_summary(sub_id=approval.sub_id)
 
     # Get the first row (should only be one)
-    subscription_summary = SubscriptionSummary(**subscription_summary[0])
+    # pylint: disable=protected-access
+    subscription_summary = SubscriptionSummary(**subscription_summary[0]._mapping)
+    # pylint: enable=protected-access
 
     current_date = datetime.date.today()
 

--- a/rctab/routers/accounting/send_emails.py
+++ b/rctab/routers/accounting/send_emails.py
@@ -364,7 +364,8 @@ def should_send_expiry_email(
     one in that period. This is to allow for emails not being sent (e.g. if
     the email service goes down). We don't send emails before this
     period (shown as ~) or on the day of expiry (denoted by x). We send daily
-    emails to active subscriptions after expiry (marked with =).
+    emails to active subscriptions after expiry (marked with =). The exact
+    date values of | are customisable via the settings module.
 
     Args:
         date_of_expiry: Expiry date of a subscription.
@@ -386,7 +387,9 @@ def should_send_expiry_email(
         else:
             return False
 
-    for days_remaining in (1, 7, 30):
+    # Not technically a frequency, more of a schedule.
+    expiry_email_schedule: List[int] = get_settings().expiry_email_freq
+    for days_remaining in expiry_email_schedule:
         if date_of_expiry <= date.today() + timedelta(days=days_remaining):
             if not date_of_last_email:
                 return True

--- a/rctab/settings.py
+++ b/rctab/settings.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     notifiable_roles: List[str] = ["Contributor"]  # Roles to email about a subscription
     roles_filter: List[str] = ["Contributor"]  # Send emails if one of these changes
     admin_email_recipients: List[str] = []  # Recipients of admin emails
+    expiry_email_freq: List[int] = [1, 7, 30]  # Days before expiry to send emails
 
     # Org name, for emails and frontend
     organisation: Optional[str] = "My organisation"

--- a/tests/test_routes/test_send_emails.py
+++ b/tests/test_routes/test_send_emails.py
@@ -920,7 +920,7 @@ async def test_expiry_looming_doesnt_resend(
     mock_send.assert_not_called()
 
 
-def test_should_send_expiry_email() -> None:
+def test_should_send_expiry_email(mocker: MockerFixture) -> None:
     # pylint: disable=using-constant-test
     # pylint: disable=invalid-name
 
@@ -1048,6 +1048,17 @@ def test_should_send_expiry_email() -> None:
             date_of_expiry, date_of_last_email, SubscriptionState.ENABLED
         )
         is True
+    )
+    # Try again but having changed the settings
+    mock_get_settings = mocker.patch(
+        "rctab.routers.accounting.send_emails.get_settings"
+    )
+    mock_get_settings.return_value.expiry_email_freq = []
+    assert (
+        send_emails.should_send_expiry_email(
+            date_of_expiry, date_of_last_email, SubscriptionState.ENABLED
+        )
+        is False
     )
 
     if False:

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -378,6 +378,7 @@ async def test_post_status_sends_looming(
     mock_get_settings.return_value.website_hostname = (
         "https://rctab-t1-teststack.azurewebsites.net/"
     )
+    mock_get_settings.return_value.expiry_email_freq = [1, 7, 30]
 
     mock_send_email = mocker.patch(
         "rctab.routers.accounting.send_emails.send_with_sendgrid"
@@ -487,7 +488,6 @@ async def test_post_status_sends_looming(
     )
 
     assert mock_send_email.call_count == 3
-    # mock_send_email.assert_has_calls([welcome_call, new_approval_call, expiry_call])
     mock_send_email.assert_has_calls([welcome_call, new_approval_call, expiry_call])
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,6 +35,7 @@ def test_minimal_settings() -> None:
     assert settings.notifiable_roles == ["Contributor"]
     assert settings.roles_filter == ["Contributor"]
     assert settings.admin_email_recipients == []
+    assert settings.expiry_email_freq == [1, 7, 30]
 
 
 def test_settings_raises() -> None:
@@ -71,6 +72,7 @@ def test_maximal_settings() -> None:
         status_func_public_key="2345",
         controller_func_public_key="1234",
         admin_email_recipients=["myemail@myorg.com"],
+        expiry_email_freq=[1, 7, 30],
         # To stop any local .env files influencing the test
         _env_file=None,
     )


### PR DESCRIPTION
- Make the schedule for expiry reminders configurable via an environment variable.
- Fix deprecation warnings from sqlalchemy/databases and jinja.

Closes #39 