### PR TITLE
example env files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+env:
+  # FastAPI session secret.
+  SESSION_SECRET: some_secret
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -49,11 +53,14 @@ jobs:
 
       - name: Run main tests
         shell: bash
-        run: CELERY_RESULT_BACKEND="redis://localhost:6379/0" scripts/runtests.sh -d -c main
+        run: |
+          export CELERY_RESULT_BACKEND="redis://localhost:6379/0"
+          scripts/runtests.sh -d -c main
 
       - name: Run route tests
         shell: bash
-        run: scripts/runtests.sh -d -c routes
+        run: |
+          scripts/runtests.sh -d -c routes
 
       - name: Check DB downgrade
         shell: bash
@@ -61,7 +68,6 @@ jobs:
         run: |
           set -a
           source example.auth.env
-          export SESSION_SECRET=$(openssl rand -hex 32)
           source example.env
           set +a
           poetry run alembic upgrade head

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           set -a
           source example.auth.env
+          export SESSION_SECRET=$(openssl rand -hex 32)
           source example.env
           set +a
           poetry run alembic upgrade head

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -24,7 +24,7 @@ Start by setting up the environment:
 poetry env use python3
 ```
 
-Now spawn a poetry shell, this will create a virtual environment for the project.
+Now spawn a Poetry shell, this will create a virtual environment for the project.
 **Keep this virtual environment activated for the remaining steps.**
 
 ```bash
@@ -74,14 +74,15 @@ cp example.env .env
 If you end up using a PostgreSQL port other than `5432` or a password other than `password` in the [PostgreSQL Container](#postgresql-container) section then you should edit `.env` to specify `DB_PORT` and/or `DB_PASSWORD`.
 For the full range of settings, see the ``settings.py`` module.
 
-Create a minimal `.auth.env` file for [Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-overview) by copying the example:
+Create a minimal `.auth.env` file for [Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-overview) by copying the example and adding a random `SESSION_SECRET`:
 
 ```bash
 cp example.auth.env .auth.env
+echo "SESSION_SECRET=$(openssl rand -hex 32)" >> .auth.env
 ```
 
 Note that these are only suitable for getting a development environment up and running.
-Never add  `.env` nor `.auth.env` to version control and do not use the default password or session secret in a real deployment.
+Never add  `.env` nor `.auth.env` to version control and do not use the default credentials in a real deployment.
 For the full explanation of the auth settings, see [Application Registration](#application-registration).
 
 [//]: # (If you wish to send email notifications, set up a SendGrid account and then replace `{YOUR_SENDGRID_KEY} with a SendGrid API key.)

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -143,7 +143,7 @@ You can stop it at any time with `docker stop rctab_db`.
 Before you start the API we must create the database schema:
 
 ```bash
-scripts/prestart.sh
+alembic upgrade head
 ```
 
 #### Running Tests

--- a/example.auth.env
+++ b/example.auth.env
@@ -1,7 +1,7 @@
 # Environment variables file. See
 # https://pydantic-docs.helpmanual.io/usage/settings/#dotenv-env-support
-SESSION_EXPIRE_TIME_MINUTES=1
-SESSION_SECRET=$(openssl rand -hex 32)
 CLIENT_ID=00000000-0000-0000-0000-000000000000
-CLIENT_SECRET=this_is_a_secret
+CLIENT_SECRET=put_your_azure_app_secret_here
 TENANT_ID=00000000-0000-0000-0000-000000000000
+SESSION_EXPIRE_TIME_MINUTES=1
+# Generate a SESSION_SECRET with e.g. `openssl rand -hex 32`


### PR DESCRIPTION
Closes #60 and closes #61.

- Change docs to recommend explicitly calling alembic, and not prestart.sh (so that you don't get redis-related errors if you don't have it running locally).
- Explicitly generate a `SESSION_SECRET` (so that you don't forget and leave the default text there).