### PR TITLE
Install redis from normal package repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,9 @@ RUN apt-get --yes install curl \
     libpq-dev \
     git \
     wget \
-    unzip
+    unzip \
+    redis
 #RUN rm -rf /var/lib/apt/lists/*
-
-# Install Redis
-# See https://redis.io/docs/install/install-redis/install-redis-on-linux/
-RUN apt-get --yes install lsb-release gpg
-RUN curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-
-RUN echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list
-
-RUN apt-get update
-RUN apt-get --yes install redis
 
 # Install Poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
The old way of installing redis doesn't seem to work with debian trixie but we can simply install it from the in-built package repositories.

An alternative would be to build Redis from source as part of the docker build. See [here](https://redis.io/docs/latest/operate/oss_and_stack/install/build-stack/debian-bookworm/) for instructions.