### PR TITLE
Don't safety scan .venv dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
         name: Safety
         entry: poetry run safety --stage cicd scan --policy-file .safety-policy.yml
         pass_filenames: false
-        files: '(pyproject\.toml|poetry\.lock)'
         language: system
       - id: mypy
         name: MyPy

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,8 +1,8 @@
 version: '3.0'
 
 scanning-settings:
-  max-depth: 6
-  exclude: []
+  max-depth: 1
+  exclude: [".venv"]
   include-files: []
   system:
     targets: []


### PR DESCRIPTION
We sometimes have linting failures when safety CLI scans the .venv directory but we only really care about our poetry.lock/pyproject.toml files.