### PR TITLE
Auth testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,9 @@
 import asyncio
-import datetime
-import subprocess
-from pathlib import Path
-from typing import Any, AsyncGenerator, Callable, Dict, Tuple
+from typing import Any, AsyncGenerator, Callable, Dict, Generator
 from uuid import UUID
 
-import jwt
 import pytest
 import pytest_asyncio
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI, Request
 from jose.jws import sign
 from sqlalchemy.ext.asyncio.engine import AsyncConnection
@@ -23,7 +17,9 @@ from rctab.crud.auth import (
     user_authenticated_no_error,
 )
 from rctab.db import ENGINE, get_async_connection
-from rctab.settings import Settings
+from rctab.routers.accounting.desired_states import authenticate_app
+from rctab.routers.accounting.status import authenticate_status_app
+from rctab.routers.accounting.usage import authenticate_usage_app
 from tests.test_routes import constants
 
 # pylint: disable=W0621
@@ -138,169 +134,23 @@ def get_token_verified_override() -> Callable:
 @pytest.fixture
 def auth_app(
     get_oauth_settings_override: Callable, get_token_verified_override: Callable
-) -> FastAPI:
+) -> Generator[FastAPI, None, None]:
     # pylint: disable=import-outside-toplevel
     from rctab import app
 
-    # Override all authentication for tests
-    app.dependency_overrides = {}
-    app.dependency_overrides[user_authenticated] = get_oauth_settings_override()
-    app.dependency_overrides[user_authenticated_no_error] = (
-        get_oauth_settings_override()
-    )
-    app.dependency_overrides[token_verified] = get_token_verified_override()
-    app.dependency_overrides[token_user_verified] = get_token_verified_override()
-    app.dependency_overrides[token_admin_verified] = get_token_verified_override()
-
-    return app
-
-
-def get_public_key_and_token(app_name: str) -> Tuple[str, str]:
-    """Sign a JWT with private key and mock get_settings with public key field"""
-    token_claims: Dict[str, Any] = {"sub": app_name}
-    access_token_expires = datetime.timedelta(minutes=10)
-
-    expire = datetime.datetime.now(datetime.UTC) + access_token_expires
-    token_claims.update({"exp": expire})
-
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-    )
-
-    public_key = private_key.public_key()
-    public_key_str = public_key.public_bytes(
-        encoding=serialization.Encoding.OpenSSH,
-        format=serialization.PublicFormat.OpenSSH,
-    ).decode("utf-8")
-
-    token = jwt.encode(token_claims, private_key, algorithm="RS256")  # type: ignore
-    return public_key_str, token
-
-
-# pylint: disable=redefined-outer-name
-@pytest.fixture
-def app_with_signed_billing_token(
-    tmp_path: Path,
-    mocker: Any,
-    get_oauth_settings_override: Callable,
-    get_token_verified_override: Callable,
-) -> Tuple[FastAPI, str]:
-    """Sign a JWT with private key and mock get_settings with public key field"""
-    private_key = tmp_path / "key"
-    public_key = tmp_path / "key.pub"
-
-    # Create a public and private_key
-    _ = subprocess.check_output(
-        ["ssh-keygen", "-t", "rsa", "-f", private_key, "-N", ""],
-        universal_newlines=True,
-    )
-
-    assert private_key.exists()
-    assert public_key.exists()
-
-    private_key_text = private_key.read_text()
-    private_key_bytes = serialization.load_ssh_private_key(  # type: ignore
-        private_key_text.encode(), password=b""
-    )
-
-    # Create jwt
-    token_claims: Dict[str, Any] = {"sub": "usage-app"}
-    access_token_expires = datetime.timedelta(minutes=10)
-
-    expire = datetime.datetime.now(datetime.UTC) + access_token_expires
-    token_claims.update({"exp": expire})
-
-    token = jwt.encode(token_claims, private_key_bytes, algorithm="RS256")  # type: ignore
-
-    def _get_settings() -> Settings:
-        return Settings(
-            usage_func_public_key=str(public_key.read_text()), ignore_whitelist=True
-        )
-
-    mocker.patch(
-        "rctab.routers.accounting.usage.get_settings", side_effect=_get_settings
-    )
-    # pylint: disable=import-outside-toplevel
-    from rctab import app
-
-    # Override all authentication for tests
-    app.dependency_overrides = {}
-    app.dependency_overrides[user_authenticated] = get_oauth_settings_override()
-    app.dependency_overrides[token_verified] = get_token_verified_override()
-    app.dependency_overrides[token_user_verified] = get_token_verified_override()
-    app.dependency_overrides[token_admin_verified] = get_token_verified_override()
-
-    return app, token
-
-
-@pytest.fixture
-def app_with_signed_status_and_controller_tokens(
-    mocker: Any,
-    get_oauth_settings_override: Callable,
-    get_token_verified_override: Callable,
-) -> Tuple[FastAPI, str, str]:
-
-    status_public_key_str, status_token = get_public_key_and_token("status-app")
-    controller_public_key_str, controller_token = get_public_key_and_token(
-        "controller-app"
-    )
-
-    def _get_settings() -> Settings:
-        return Settings(
-            controller_func_public_key=controller_public_key_str,
-            status_func_public_key=status_public_key_str,
-            ignore_whitelist=True,
-        )
-
-    mocker.patch(
-        "rctab.routers.accounting.status.get_settings", side_effect=_get_settings
-    )
-    mocker.patch(
-        "rctab.routers.accounting.desired_states.get_settings",
-        side_effect=_get_settings,
-    )
-
-    # pylint: disable=import-outside-toplevel
-    from rctab import app
-
-    # Override all authentication for tests
-    app.dependency_overrides = {}
-    app.dependency_overrides[user_authenticated] = get_oauth_settings_override()
-    app.dependency_overrides[token_verified] = get_token_verified_override()
-    app.dependency_overrides[token_user_verified] = get_token_verified_override()
-    app.dependency_overrides[token_admin_verified] = get_token_verified_override()
-
-    return app, status_token, controller_token
-
-
-@pytest.fixture
-def app_with_signed_status_token(
-    mocker: Any,
-    get_oauth_settings_override: Callable,
-    get_token_verified_override: Callable,
-) -> Tuple[FastAPI, str]:
-
-    status_public_key_str, status_token = get_public_key_and_token("status-app")
-
-    def _get_settings() -> Settings:
-        return Settings(
-            status_func_public_key=status_public_key_str, ignore_whitelist=True
-        )
-
-    mocker.patch(
-        "rctab.routers.accounting.status.get_settings", side_effect=_get_settings
-    )
-
-    # pylint: disable=import-outside-toplevel
-    from rctab import app
+    async def bypass_app_token() -> Dict[str, str]:
+        return {}
 
     # Override all authentication for tests
     app.dependency_overrides = {
         user_authenticated: get_oauth_settings_override(),
+        user_authenticated_no_error: get_oauth_settings_override(),
         token_verified: get_token_verified_override(),
         token_user_verified: get_token_verified_override(),
         token_admin_verified: get_token_verified_override(),
+        authenticate_status_app: bypass_app_token,
+        authenticate_usage_app: bypass_app_token,
+        authenticate_app: bypass_app_token,
     }
-
-    return app, status_token
+    yield app
+    app.dependency_overrides = {}

--- a/tests/test_routes/api_calls.py
+++ b/tests/test_routes/api_calls.py
@@ -53,7 +53,6 @@ def create_subscription(client: TestClient, subscription_id: UUID) -> Response:
 
 def create_subscription_detail(
     client: TestClient,
-    token: str,
     subscription_id: UUID,
     state: SubscriptionState,
     role_assignments: Optional[Tuple[RoleAssignment, ...]] = (),
@@ -72,7 +71,6 @@ def create_subscription_detail(
                 )
             ]
         ).model_dump_json(),
-        headers={"authorization": "Bearer " + token},
     )
 
 
@@ -128,7 +126,6 @@ def create_allocation(
 
 def create_usage(
     client: TestClient,
-    token: str,
     subscription_id: UUID,
     cost: float = 0.0,
     amortised_cost: float = 0.0,
@@ -178,5 +175,4 @@ def create_usage(
     return client.post(
         "usage/all-usage",
         content=post_data.model_dump_json(),
-        headers={"authorization": "Bearer " + token},
     )

--- a/tests/test_routes/test_authentication.py
+++ b/tests/test_routes/test_authentication.py
@@ -1,0 +1,225 @@
+"""One test per protected route verifying that unauthenticated requests are rejected."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from rctab import app
+
+
+@pytest.fixture(autouse=True)
+def no_auth_overrides() -> None:
+    """Ensure dependency overrides are clear so real auth is enforced."""
+    app.dependency_overrides = {}
+
+
+# --- token_admin_verified routes ---
+
+
+@pytest.mark.asyncio
+async def test_topup_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/topup")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_allocations_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/allocations")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_approvals_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/approvals")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_approve_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/approve")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_cli_cost_recovery_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/cli-cost-recovery")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_cli_cost_recovery_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/cli-cost-recovery")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_finance_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/finance")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_finances_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/finances")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_put_finance_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.put("/accounting/finances/1")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_finance_by_id_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/finances/1")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_finance_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.delete("/accounting/finances/1")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_persistent_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/persistent")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/subscription")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_subscription_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/subscription")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_id_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/subscription-id")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_all_usage_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/all-usage")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_all_cm_usage_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/all-cm-usage")
+    assert response.status_code == 401
+
+
+# --- app-token routes (authenticate_status_app / authenticate_usage_app / authenticate_app) ---
+
+
+@pytest.mark.asyncio
+async def test_post_all_status_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/all-status")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_app_cost_recovery_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/app-cost-recovery")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_all_usage_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/all-usage")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_monthly_usage_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/monthly-usage")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_all_cm_usage_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/accounting/all-cm-usage")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_desired_states_requires_auth() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/accounting/desired-states")
+    assert response.status_code == 401

--- a/tests/test_routes/test_authentication.py
+++ b/tests/test_routes/test_authentication.py
@@ -12,9 +12,6 @@ def no_auth_overrides() -> None:
     app.dependency_overrides = {}
 
 
-# --- token_admin_verified routes ---
-
-
 @pytest.mark.asyncio
 async def test_topup_requires_auth() -> None:
     async with AsyncClient(
@@ -166,9 +163,6 @@ async def test_get_all_cm_usage_requires_auth() -> None:
     ) as client:
         response = await client.get("/accounting/all-cm-usage")
     assert response.status_code == 401
-
-
-# --- app-token routes (authenticate_status_app / authenticate_usage_app / authenticate_app) ---
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes/test_cost_recovery.py
+++ b/tests/test_routes/test_cost_recovery.py
@@ -1,6 +1,5 @@
 import random
 from datetime import date
-from typing import Tuple
 from unittest.mock import ANY, AsyncMock
 from uuid import UUID
 
@@ -35,12 +34,11 @@ async def fetch_all(conn: AsyncConnection, query: Select) -> list[dict]:
 
 
 def test_cost_recovery_app_route(
-    app_with_signed_billing_token: Tuple[FastAPI, str],
+    auth_app: FastAPI,
     mocker: MockerFixture,
 ) -> None:
     """Check we can cost-recover a month."""
 
-    auth_app, token = app_with_signed_billing_token
     with TestClient(auth_app) as client:
 
         mock = AsyncMock()
@@ -50,7 +48,6 @@ def test_cost_recovery_app_route(
         result = client.post(
             PREFIX + "/app-cost-recovery",
             content=recovery_period.model_dump_json(),
-            headers={"authorization": "Bearer " + token},
         )
 
         mock.assert_called_once_with(

--- a/tests/test_routes/test_desired_states.py
+++ b/tests/test_routes/test_desired_states.py
@@ -222,9 +222,6 @@ async def test_desired_states_disabled(
         "rctab.routers.accounting.desired_states.refresh_desired_states", mock_refresh
     )
 
-    auth_app.dependency_overrides[desired_states.authenticate_app] = lambda: {
-        "sub": "controller-app"
-    }
     auth_app.dependency_overrides[get_async_connection] = _get_async_connection_override
 
     async with AsyncClient(
@@ -295,9 +292,6 @@ async def test_desired_states_enabled(
         "rctab.routers.accounting.desired_states.refresh_desired_states", mock_refresh
     )
 
-    auth_app.dependency_overrides[desired_states.authenticate_app] = lambda: {
-        "sub": "controller-app"
-    }
     auth_app.dependency_overrides[get_async_connection] = _get_async_connection_override
 
     async with AsyncClient(

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 from unittest.mock import ANY, AsyncMock
 from uuid import UUID, uuid4
 
@@ -43,12 +43,10 @@ def unique_test_sub_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
 )
 @given(st.lists(st.builds(SubscriptionStatus), min_size=2, max_size=20, unique=True))
 def test_post_status(
-    app_with_signed_status_token: Tuple[FastAPI, str],
+    auth_app: FastAPI,
     mocker: pytest_mock.MockerFixture,
     status_list: List[SubscriptionStatus],
 ) -> None:
-    auth_app, token = app_with_signed_status_token
-
     with TestClient(auth_app) as client:
         all_status = AllSubscriptionStatus(status_list=status_list)
 
@@ -65,7 +63,6 @@ def test_post_status(
         resp = client.post(
             "accounting/all-status",
             content=all_status.model_dump_json().encode("utf-8"),
-            headers={"authorization": "Bearer " + token},
         )
         assert resp.status_code == 200
 
@@ -79,7 +76,6 @@ def test_post_status(
         resp = client.post(
             "accounting/all-status",
             content=all_status.model_dump_json(),
-            headers={"authorization": "Bearer " + token},
         )
         assert resp.status_code == 200
 

--- a/tests/test_routes/test_subscription.py
+++ b/tests/test_routes/test_subscription.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 from uuid import UUID
 
 import pytest
@@ -68,11 +67,9 @@ async def test_post_subscription_twice(
 
 
 def test_get_subscription_summary(
-    app_with_signed_status_and_controller_tokens: Tuple[FastAPI, str, str],
+    auth_app: FastAPI,
 ) -> None:
     """Get subscription information"""
-    auth_app, status_token, _ = app_with_signed_status_and_controller_tokens
-
     expected_details = SubscriptionDetails(
         subscription_id=constants.TEST_SUB_UUID,
         name="sub display name",
@@ -97,7 +94,6 @@ def test_get_subscription_summary(
 
         result = api_calls.create_subscription_detail(
             client,
-            status_token,
             constants.TEST_SUB_UUID,
             SubscriptionState.ENABLED,
             role_assignments=(),
@@ -110,11 +106,9 @@ def test_get_subscription_summary(
 
 # here
 def test_get_subscription_id(
-    app_with_signed_status_and_controller_tokens: Tuple[FastAPI, str, str],
+    auth_app: FastAPI,
 ) -> None:
     """Returns a subscription id, given a subscription name."""
-    auth_app, status_token, _ = app_with_signed_status_and_controller_tokens
-
     with TestClient(auth_app) as client:
         # Check the scenario with no matches.
         result = client.get(
@@ -131,7 +125,6 @@ def test_get_subscription_id(
 
         api_calls.create_subscription_detail(
             client=client,
-            token=status_token,
             subscription_id=constants.TEST_SUB_UUID,
             state=SubscriptionState.ENABLED,
             display_name="MyDisplayName",
@@ -151,7 +144,6 @@ def test_get_subscription_id(
 
         api_calls.create_subscription_detail(
             client=client,
-            token=status_token,
             subscription_id=constants.TEST_SUB_2_UUID,
             state=SubscriptionState.ENABLED,
             display_name="MyDisplayName",

--- a/tests/test_routes/test_usage.py
+++ b/tests/test_routes/test_usage.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from pathlib import Path
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable, List, Union
 from unittest.mock import ANY, AsyncMock
 from uuid import UUID, uuid4
 
@@ -51,10 +51,9 @@ TICKET = "T001-12"
 
 
 def test_post_usage(
-    app_with_signed_billing_token: Tuple[FastAPI, str],
+    auth_app: FastAPI,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    auth_app, token = app_with_signed_billing_token
     example_usage_file = Path("tests/data/example.json")
 
     example_usage_data: Iterable[dict] = json.loads(
@@ -82,7 +81,6 @@ def test_post_usage(
         resp = client.post(
             "usage/all-usage",
             content=post_data.model_dump_json().encode("utf-8"),
-            headers={"authorization": "Bearer " + token},
         )
 
         assert resp.status_code == 200
@@ -97,7 +95,6 @@ def test_post_usage(
 
         get_resp = client.get(
             "usage/all-usage",
-            headers={"authorization": "Bearer " + token},
         )
 
         assert get_resp.status_code == 200
@@ -224,10 +221,7 @@ async def test_post_usage3(
     assert len(sub_usage) == 2
 
 
-def test_write_usage(
-    app_with_signed_billing_token: Tuple[FastAPI, str], mocker: MockerFixture
-) -> None:
-    auth_app, token = app_with_signed_billing_token
+def test_write_usage(auth_app: FastAPI, mocker: MockerFixture) -> None:
     expected_details = SubscriptionDetails(
         subscription_id=constants.TEST_SUB_UUID,
         approved_from=date_from,
@@ -273,7 +267,6 @@ def test_write_usage(
         assert (
             api_calls.create_usage(
                 client,
-                token,
                 constants.TEST_SUB_UUID,
                 cost=50.0,
                 date=datetime.datetime(2024, 2, 2),
@@ -284,7 +277,6 @@ def test_write_usage(
         assert (
             api_calls.create_usage(
                 client,
-                token,
                 constants.TEST_SUB_UUID,
                 cost=20.00,
                 date=datetime.datetime(2024, 2, 3),
@@ -295,7 +287,6 @@ def test_write_usage(
         assert (
             api_calls.create_usage(
                 client,
-                token,
                 constants.TEST_SUB_UUID,
                 cost=5.340,
                 date=datetime.datetime(2024, 2, 4),
@@ -306,10 +297,7 @@ def test_write_usage(
         api_calls.assert_subscription_status(client, expected_details)
 
 
-def test_greater_budget(
-    app_with_signed_billing_token: Tuple[FastAPI, str], mocker: MockerFixture
-) -> None:
-    auth_app, token = app_with_signed_billing_token
+def test_greater_budget(auth_app: FastAPI, mocker: MockerFixture) -> None:
     expected_details = SubscriptionDetails(
         subscription_id=constants.TEST_SUB_UUID,
         approved_from=date_from,
@@ -355,7 +343,6 @@ def test_greater_budget(
         assert (
             api_calls.create_usage(
                 client,
-                token,
                 constants.TEST_SUB_UUID,
                 cost=100.0,
                 date=datetime.datetime(2024, 2, 2),
@@ -366,7 +353,6 @@ def test_greater_budget(
         assert (
             api_calls.create_usage(
                 client,
-                token,
                 constants.TEST_SUB_UUID,
                 cost=50.0,
                 date=datetime.datetime(2024, 2, 3),
@@ -379,34 +365,29 @@ def test_greater_budget(
 
 def _post_costmanagement(
     client: Union[requests.Session, TestClient],
-    token: str,
     data: List[CMUsage],
 ) -> requests.Response:
     all_usage = AllCMUsage(cm_usage_list=data)
     post_client = client.post(
         "/usage/all-cm-usage",
-        headers={"authorization": "Bearer " + token},
         content=all_usage.model_dump_json().encode("utf-8"),
     )  # type: ignore
     return post_client  # type: ignore
 
 
 def _get_costmanagement(
-    client: Union[requests.Session, TestClient], token: str
+    client: Union[requests.Session, TestClient],
 ) -> requests.Response:
-    return client.get(
-        "/usage/all-cm-usage", headers={"authorization": "Bearer " + token}
-    )  # type: ignore
+    return client.get("/usage/all-cm-usage")  # type: ignore
 
 
 def test_write_read_costmanagement(
-    app_with_signed_billing_token: Tuple[FastAPI, str],
+    auth_app: FastAPI,
 ) -> None:
     """POST some cost-management data, GET it back, and check that the response matches
     the input. Do it twice, because the first time inserts new subscriptions, whereas
     the second updates existing ones.
     """
-    auth_app, token = app_with_signed_billing_token
     end_date = datetime.datetime.now().date()
     start_date = end_date - datetime.timedelta(days=364)
     sub_data_in = [
@@ -429,9 +410,9 @@ def test_write_read_costmanagement(
     ]
     with TestClient(auth_app) as client:
         for _ in range(2):
-            response = _post_costmanagement(client, token, sub_data_in)
+            response = _post_costmanagement(client, sub_data_in)
             assert response.status_code == 200
-            response = _get_costmanagement(client, token)
+            response = _get_costmanagement(client)
             assert response.status_code == 200
             sub_data_out = response.json()
             sub_data_out = [CMUsage(**d) for d in sub_data_out]
@@ -440,11 +421,9 @@ def test_write_read_costmanagement(
 
 
 def test_post_monthly_usage(
-    app_with_signed_billing_token: Tuple[FastAPI, str],
+    auth_app: FastAPI,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    auth_app, token = app_with_signed_billing_token
-
     example_1_file = Path("tests/data/example-monthly-wrong.json")
     example_1_data = json.loads(example_1_file.read_text(encoding="utf-8"))
     sub_map_1: dict[str, UUID] = {}
@@ -488,7 +467,6 @@ def test_post_monthly_usage(
             )
             .model_dump_json()
             .encode("utf-8"),
-            headers={"authorization": "Bearer " + token},
         )
 
         assert resp.status_code == 400
@@ -497,7 +475,6 @@ def test_post_monthly_usage(
         resp = client.post(
             "usage/monthly-usage",
             content=post_example_1_data.model_dump_json().encode("utf-8"),
-            headers={"authorization": "Bearer " + token},
         )
 
         assert resp.status_code == 400
@@ -506,14 +483,12 @@ def test_post_monthly_usage(
         resp = client.post(
             "usage/monthly-usage",
             content=post_example_2_data.model_dump_json().encode("utf-8"),
-            headers={"authorization": "Bearer " + token},
         )
 
         assert resp.status_code == 200
 
         get_resp = client.get(
             "usage/all-usage",
-            headers={"authorization": "Bearer " + token},
         )
 
         assert get_resp.status_code == 200
@@ -643,12 +618,11 @@ async def test_post_usage_refreshes_view(
 
 
 def test_post_usage_emails(
-    app_with_signed_billing_token: Tuple[FastAPI, str],
+    auth_app: FastAPI,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """Check that we send the correct emails."""
 
-    auth_app, token = app_with_signed_billing_token
     example_usage_file = Path("tests/data/example.json")
     example_usage_data = json.loads(example_usage_file.read_text(encoding="utf-8"))
     sub_map: dict[str, UUID] = {}
@@ -677,7 +651,6 @@ def test_post_usage_emails(
         resp = client.post(
             "usage/all-usage",
             content=post_data.model_dump_json().encode("utf-8"),
-            headers={"authorization": "Bearer " + token},
         )
         assert resp.status_code == 200
 

--- a/tests/test_routes/utils.py
+++ b/tests/test_routes/utils.py
@@ -1,65 +1,23 @@
-# from asyncio import sleep
 from typing import AsyncGenerator
 
 import pytest_asyncio
 from sqlalchemy.ext.asyncio.engine import AsyncConnection
-from sqlalchemy.sql.expression import text
 
 from rctab.db import ENGINE
-
-# from rctab.settings import get_settings
 
 
 @pytest_asyncio.fixture(scope="function")
 async def no_rollback_test_db() -> AsyncGenerator[AsyncConnection, None]:
-    """Connect before & disconnect after each test."""
+    """Connect before & disconnect after each test.
 
-    # For a small number of tests, we want to ensure the same
-    # rollback behaviour as on the live db as we are specifically
-    # testing that transactions and rollbacks are handled well.
-    # database = Database(str(get_settings().postgres_dsn), force_rollback=False)
-
-    # If you want to use the database fixture, uncomment the line below
-    print("CONNECTING...", flush=True)
+    For a small number of tests, we want to test that calc_cost_recovery's
+    internal savepoint (begin_nested) commits or rolls back correctly. This
+    fixture provides a real outer transaction to wrap that savepoint in.
+    The outer transaction is always rolled back after the test.
+    """
     async with ENGINE.connect() as conn:
-        print("TRANSACTION...", flush=True)
-        # await conn.commit()
         trans = await conn.begin()
         try:
             yield conn
         finally:
-            print("ROLLBACK...", flush=True)
             await trans.rollback()
-        print("CLEANUP...", flush=True)
-        await clean_up(conn)
-        await conn.commit()
-    return
-    # await database.connect()
-    # print("CONNECTING...", flush=True)
-    # conn = await ENGINE.connect()
-    # print("CONNECTED...", flush=True)
-    # yield conn
-    # print("CLEANING UP...", flush=True)
-    # await clean_up(conn)
-    # print("CLEANED UP...", flush=True)
-    # await sleep(1)
-
-
-async def clean_up(conn: AsyncConnection) -> None:
-    """Deletes data from all accounting tables."""
-
-    for table_name in (
-        "status",
-        "usage",
-        "allocations",
-        "approvals",
-        "persistence",
-        "emails",
-        "cost_recovery",
-        "finance",
-        "finance_history",
-        "subscription",
-        "cost_recovery_log",
-    ):
-        # print(f"Cleaning up table: {table_name}", flush=True)
-        await conn.execute(text(f"delete from accounting.{table_name}"))


### PR DESCRIPTION
Moves testing of endpoint authentication into one file (where we have one test per endpoint and check that we get 401 if we're not authenticated). 

Simplify (i.e. bypass) authentication for other tests.