### PR TITLE
Fix CI coverage reporting and surface it via badge + PR comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - released
       - prereleased
 
+permissions:
+  contents: read
+
 jobs:
   deploy_to_docker_hub:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: gitleaks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,19 @@ env:
   # FastAPI session secret.
   SESSION_SECRET: some_secret
 
+# Least-privilege default; the test job overrides with the scopes it needs.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    # For python-coverage-comment-action: PR comment + push to data branch.
+    permissions:
+      contents: write
+      pull-requests: write
 
     strategy:
       matrix:
@@ -55,6 +64,12 @@ jobs:
         shell: bash
         run: |
           scripts/runtests.sh -c routes -s
+
+      # Combined main + routes coverage is complete here.
+      - name: Publish coverage comment and badge
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Check DB downgrade
         shell: bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![docker-deploy](https://github.com/alan-turing-institute/rctab-api/actions/workflows/deploy.yml/badge.svg)
 ![tests](https://github.com/alan-turing-institute/rctab-api/actions/workflows/test.yml/badge.svg)
+[![Coverage badge](https://raw.githubusercontent.com/alan-turing-institute/rctab-api/python-coverage-comment-action-data/badge.svg)](https://github.com/alan-turing-institute/rctab-api/tree/python-coverage-comment-action-data)
 ![linter](https://github.com/alan-turing-institute/rctab-api/actions/workflows/linter.yml/badge.svg)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![Documentation Status](https://readthedocs.org/projects/rctab-api/badge/?version=latest)](https://rctab-api.readthedocs.io/en/latest/?badge=latest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ profile = "black"
 [tool.black]
 line-length = 88
 
+[tool.coverage.run]
+# Relative paths so python-coverage-comment-action can build the badge/comment.
+relative_files = true
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -170,15 +170,12 @@ poetry run alembic upgrade head
 # Run tests
 export TESTING=true
 if [ "$TEST_CONFIGURATION" = "main" ]; then
-    # Collect coverage from a clean baseline but don't print a report yet: on its
-    # own the "main" configuration excludes tests/test_routes/ and so reports
-    # misleadingly low coverage. The combined report is printed by the "routes"
-    # configuration, which appends to the .coverage data this run produces.
+    # Collect a clean baseline but don't report yet: alone, "main" excludes
+    # test_routes/ and under-reports. The "routes" run prints the combined report.
     CONFIGURATION_ARGS=(--hypothesis-show-statistics --cov-report= --cov rctab --ignore tests/test_routes/)
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "routes" ]; then
-    # Append route-test coverage to any data left by the "main" configuration and
-    # print the combined report, so coverage reflects the whole test suite.
+    # Append to "main" coverage and print the combined report for the whole suite.
     CONFIGURATION_ARGS=(--cov-append --cov-report term-missing --cov rctab ./tests/test_routes/)
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "migrations" ]; then

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -170,10 +170,16 @@ poetry run alembic upgrade head
 # Run tests
 export TESTING=true
 if [ "$TEST_CONFIGURATION" = "main" ]; then
-    CONFIGURATION_ARGS=(--hypothesis-show-statistics --cov-report term-missing --cov rctab --ignore tests/test_routes/)
+    # Collect coverage from a clean baseline but don't print a report yet: on its
+    # own the "main" configuration excludes tests/test_routes/ and so reports
+    # misleadingly low coverage. The combined report is printed by the "routes"
+    # configuration, which appends to the .coverage data this run produces.
+    CONFIGURATION_ARGS=(--hypothesis-show-statistics --cov-report= --cov rctab --ignore tests/test_routes/)
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "routes" ]; then
-    CONFIGURATION_ARGS=(./tests/test_routes/)
+    # Append route-test coverage to any data left by the "main" configuration and
+    # print the combined report, so coverage reflects the whole test suite.
+    CONFIGURATION_ARGS=(--cov-append --cov-report term-missing --cov rctab ./tests/test_routes/)
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "migrations" ]; then
     poetry run alembic upgrade head

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -170,12 +170,11 @@ poetry run alembic upgrade head
 # Run tests
 export TESTING=true
 if [ "$TEST_CONFIGURATION" = "main" ]; then
-    # Collect a clean baseline but don't report yet: alone, "main" excludes
-    # test_routes/ and under-reports. The "routes" run prints the combined report.
+    # Collect a clean baseline but don't report yet.
     CONFIGURATION_ARGS=(--hypothesis-show-statistics --cov-report= --cov rctab --ignore tests/test_routes/)
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "routes" ]; then
-    # Append to "main" coverage and print the combined report for the whole suite.
+    # Append to "main" coverage and print the combined report.
     CONFIGURATION_ARGS=(--cov-append --cov-report term-missing --cov rctab ./tests/test_routes/)
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "migrations" ]; then


### PR DESCRIPTION
## What & why

CI coverage was only reported by the **main** test configuration, which `--ignore`s `tests/test_routes/`, so the only coverage number CI ever printed counted just the non-route tests — misleadingly low. It was also buried in the workflow logs.

## Changes

**Fix the measurement** (`scripts/runtests.sh`)
- `main` collects coverage into a clean baseline but suppresses its own (partial) report.
- `routes` appends to that baseline and prints the **combined** `term-missing` report for the whole suite. Both steps run in the same CI job, so `.coverage` persists between them.

**Surface the result** ([`py-cov-action/python-coverage-comment-action`](https://github.com/py-cov-action/python-coverage-comment-action))
- A coverage **comment on every PR**, and a self-hosted **README badge** stored in the `python-coverage-comment-action-data` branch — no third-party service or token (uses the built-in `GITHUB_TOKEN`).
- `pyproject.toml`: `[tool.coverage.run] relative_files = true`, required by the action.

**Harden token permissions** (all workflows)
- Pin least-privilege `GITHUB_TOKEN` scopes everywhere instead of relying on the repo-wide default. Only the `test` job gets `contents: write` + `pull-requests: write` (needed by the coverage action); everything else is `contents: read`.

## Notes
- Verified locally against Postgres + Redis: `main` (13 passed) and `routes` (169 passed) produce a combined **84%** report.
- The README badge branch has been seeded with a placeholder; the action overwrites it with the authoritative value on the first `main` run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)