### PR TITLE
Downgrade to the special alembic "base" migration

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -179,7 +179,7 @@ elif [ "$TEST_CONFIGURATION" = "routes" ]; then
     poetry run pytest "${EXTRA_ARGS[@]}" "${CONFIGURATION_ARGS[@]}"
 elif [ "$TEST_CONFIGURATION" = "migrations" ]; then
     poetry run alembic upgrade head
-    poetry run alembic downgrade b65796c99771
+    poetry run alembic downgrade base
     poetry run alembic upgrade head
 else
     poetry run pytest "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
Instead of hard-coding the hash of the first migration, downgrade all the way. Two advantages:

1. Also checks the downgrade-ability of the initial migration.
2. Doesn't require us to know (or ever update) the hash of the first migration.