### PR TITLE
Remove get_usage route decorator

### DIFF
--- a/rctab/routers/accounting/usage.py
+++ b/rctab/routers/accounting/usage.py
@@ -225,7 +225,6 @@ async def post_usage(
     )
 
 
-@router.get("/all-usage", response_model=List[Usage])
 async def get_usage(
     _: UserRBAC = Depends(token_admin_verified),
     conn: AsyncConnection = Depends(get_async_connection),

--- a/tests/test_routes/test_usage.py
+++ b/tests/test_routes/test_usage.py
@@ -5,7 +5,6 @@ from typing import Iterable, List, Union
 from unittest.mock import ANY, AsyncMock
 from uuid import UUID, uuid4
 
-import numpy as np
 import pytest
 import pytest_mock
 import requests
@@ -93,17 +92,8 @@ def test_post_usage(
             list({x.subscription_id for x in post_data.usage_list}),
         )
 
-        get_resp = client.get(
-            "usage/all-usage",
-        )
-
-        assert get_resp.status_code == 200
-
-        resp_data = get_resp.json()
-        assert np.isclose(
-            sum(i["total_cost"] for i in resp_data),
-            sum(i.total_cost for i in post_data.usage_list),
-        )
+        get_resp = client.get("usage/all-usage")
+        assert get_resp.status_code == 405
 
 
 @pytest.mark.asyncio
@@ -487,19 +477,8 @@ def test_post_monthly_usage(
 
         assert resp.status_code == 200
 
-        get_resp = client.get(
-            "usage/all-usage",
-        )
-
-        assert get_resp.status_code == 200
-
-        resp_data = get_resp.json()
-        expected_ids = {item.id for item in post_example_2_data.usage_list}
-        resp_usage = [Usage(**item) for item in resp_data if item["id"] in expected_ids]
-        assert np.isclose(
-            sum(i.total_cost for i in resp_usage),
-            sum(i.total_cost for i in post_example_2_data.usage_list),
-        )
+        get_resp = client.get("usage/all-usage")
+        assert get_resp.status_code == 405
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Remove the FastAPI GET route decorator from `get_usage`, leaving it as an internal helper used by tests rather than an externally callable endpoint.

The existing route tests now verify that `GET /usage/all-usage` is not exposed while the POST usage endpoint remains unchanged.

Closes #74

## Tests

Updated `tests/test_routes/test_usage.py` to expect HTTP 405 for GET requests to `/usage/all-usage`.