### PR TITLE
Remove unused Linux packages from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,8 @@ RUN apt-get update
 RUN apt-get --yes install curl \
     build-essential \
     libffi-dev \
-    shared-mime-info \
     libpq-dev \
     git \
-    wget \
-    unzip \
     redis
 #RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Remove three Linux packages that are no longer required by the current RCTab image:

- `shared-mime-info`
- `wget`
- `unzip`

Packages still used by the build or runtime are left unchanged: `curl` installs Poetry, `git` is required by the Git dependency in `pyproject.toml`, and Redis is started by `prestart.sh`. Native build and PostgreSQL development packages are also retained.

Closes #62

## Tests

Dockerfile-only dependency reduction. CI image build will validate that application dependencies still install successfully.