### PR TITLE
Skip email notifications for abolished subscriptions

### DIFF
--- a/rctab/routers/accounting/send_emails.py
+++ b/rctab/routers/accounting/send_emails.py
@@ -204,6 +204,13 @@ async def send_generic_email(
     sub_summary = await _fetch_one(
         database, get_subscriptions_summary(sub_id=subscription_id)
     )
+    if sub_summary and sub_summary["abolished"]:
+        logger.info(
+            "Subscription %s is abolished and will not receive email notifications.",
+            subscription_id,
+        )
+        return
+
     subscription_name = None
     if sub_summary:
         template_data["summary"] = dict(sub_summary)
@@ -639,8 +646,8 @@ def prepare_roles_email(
 
     Given a new and an old SubscriptionStatus, return a dictionary of arguments that can be given
     as `send_generic_email(**prepare_roles_email(...))` to send a role assignment change
-    email. Unless the new and the old role assignment are the same, and thus no email is
-    needed, in which case return an empty dictionary.
+    email. Unless the new and the old role assignment are the same, and thus no email
+    is needed, in which case return an empty dictionary.
     """
     # Convert to Dicts so we can remove items
     old_rbac = [x.model_dump() for x in old_status.role_assignments]
@@ -840,7 +847,7 @@ def extract_sub_id(my_dict: Mapping) -> UUID:
 async def prepare_summary_email(
     database: AsyncConnection, since_this_datetime: Optional[datetime] = None
 ) -> dict:
-    """Prepares and returns data needed to send summary email.
+    """Prepares and returns data needed for the summary email.
 
     Args:
         database: a Database, with record of Azure subscriptions

--- a/tests/test_routes/test_abolished_emails.py
+++ b/tests/test_routes/test_abolished_emails.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from pytest_mock import MockerFixture
+
+from rctab.routers.accounting import send_emails
+
+
+@pytest.mark.asyncio
+async def test_send_generic_email_skips_abolished_subscription(
+    mocker: MockerFixture,
+) -> None:
+    """Abolished subscriptions must not receive any email notification."""
+    database = AsyncMock()
+    subscription_id = uuid4()
+
+    settings = mocker.patch("rctab.routers.accounting.send_emails.get_settings")
+    settings.return_value.ignore_whitelist = True
+
+    fetch_one = mocker.patch(
+        "rctab.routers.accounting.send_emails._fetch_one",
+        new_callable=AsyncMock,
+    )
+    fetch_one.return_value = {"abolished": True, "name": "abolished subscription"}
+
+    get_recipients = mocker.patch(
+        "rctab.routers.accounting.send_emails.get_sub_email_recipients",
+        new_callable=AsyncMock,
+    )
+    send_with_sendgrid = mocker.patch(
+        "rctab.routers.accounting.send_emails.send_with_sendgrid"
+    )
+
+    await send_emails.send_generic_email(
+        database,
+        subscription_id,
+        "blank.html",
+        "Subject:",
+        "test",
+        {},
+    )
+
+    fetch_one.assert_awaited_once()
+    get_recipients.assert_not_awaited()
+    send_with_sendgrid.assert_not_called()


### PR DESCRIPTION
Closes #79.

## Summary

Prevent abolished subscriptions from receiving email notifications by enforcing the check in `send_generic_email`, the shared email-dispatch path.

- read the existing `abolished` value from the subscription summary
- return before recipient lookup or SendGrid dispatch when the subscription is abolished
- log why the notification was skipped
- add a focused regression test verifying recipient lookup and SendGrid are never called

## Why

Keeping the guard in the common dispatch function covers approval, status, usage, expiry and other notification paths without duplicating abolishment checks throughout the codebase.

## Tests

Added `tests/test_routes/test_abolished_emails.py` covering the abolished-subscription early return.